### PR TITLE
Fix exporting sawyer as json

### DIFF
--- a/lib/bugsnag_error_event_downloader/cli.rb
+++ b/lib/bugsnag_error_event_downloader/cli.rb
@@ -4,7 +4,7 @@ module BugsnagErrorEventDownloader
   class CLI < Thor
     class_option :token,
       aliases: ["-t"],
-      banner: "BUGSNAG_PARSONAL_ACCESS_TOKEN",
+      banner: "BUGSNAG_PERSONAL_AUTH_TOKEN",
       type: :string,
       desc: "Path to the BUGSNAG_PERSONAL_AUTH_TOKEN with -t, "\
         "or set environment variable to BUGSNAG_PERSONAL_AUTH_TOKEN."

--- a/lib/bugsnag_error_event_downloader/converter/csv_converter.rb
+++ b/lib/bugsnag_error_event_downloader/converter/csv_converter.rb
@@ -21,10 +21,10 @@ module BugsnagErrorEventDownloader
           headers = csv_map.map { |m| m["header"] }
           rows << headers
           events.each do |event|
+            json = deep_hash(event).to_json
             paths = csv_map.map { |m| m["path"] }
             row = paths.map do |path|
               json_path = JsonPath.new(path)
-              json = event.to_h.to_json
               begin
                 json_path.on(json).uniq.join(",")
               rescue ArgumentError
@@ -37,6 +37,21 @@ module BugsnagErrorEventDownloader
       end
 
       private
+
+      def deep_hash(object)
+        case object
+        when Hash
+          object.each_with_object({}) do |(key, value), hash|
+            hash[key] = deep_hash(value)
+          end
+        when Array
+          object.map { |value| deep_hash(value) }
+        when Sawyer::Resource
+          deep_hash(object.to_h)
+        else
+          object
+        end
+      end
 
       def parse_csv_map(path)
         csv_map_file = File.read(path)


### PR DESCRIPTION
## Why

When exporting variable, it exports `#<Sawyer::Resource:0x00000001201eb678>` string as sidekiq argument.
I want to get the parameter what the sidekiq used as hash or JSON.

## How

Exporting hash variable to make hash deeply.

The same code is existed in `BugsnagErrorEventDownloader::Commands::GenerateCsvMap`, but it is not needed to modify. (This may make too much parameters.)