### PR TITLE
Add start and end date parameters

### DIFF
--- a/lib/bugsnag_error_event_downloader/bugsnag_api_client/error_event_client.rb
+++ b/lib/bugsnag_error_event_downloader/bugsnag_api_client/error_event_client.rb
@@ -5,7 +5,12 @@ require "forwardable"
 module BugsnagErrorEventDownloader
   module BugsnagApiClient
     class ErrorEventClient
-      def initialize(project_id:, error_id:)
+      def initialize(
+        project_id:,
+        error_id:,
+        start_date: nil,
+        end_date: Time.now.to_i
+      )
         @client = Client.new
 
         errors = []
@@ -15,12 +20,22 @@ module BugsnagErrorEventDownloader
 
         @project_id = project_id
         @error_id = error_id
+        @start_date = start_date ? Time.at(start_date).utc : Time.at(end_date).utc - (60 * 60 * 24 * 1)
+        @end_date = Time.at(end_date).utc
       end
 
-      attr_reader :client, :project_id, :error_id
+      attr_reader :client, :project_id, :error_id, :start_date, :end_date
 
       def fetch_first
-        fetch
+        events = []
+        error_events = fetch(base_time: end_date)
+        error_events.each do |error_event|
+          return events if error_event.received_at < start_date
+
+          events << error_event
+        end
+        events.uniq!(&:id)
+        events
       end
 
       def fetch_all
@@ -30,11 +45,11 @@ module BugsnagErrorEventDownloader
 
       private
 
-      def fetch(base_time: Time.now.utc.strftime("%Y-%m-%dT%H:%M:%SZ"))
+      def fetch(base_time:)
         client.error_events(
           project_id,
           error_id,
-          base: base_time,
+          base: base_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
           full_reports: true
         )
       end
@@ -43,9 +58,13 @@ module BugsnagErrorEventDownloader
         events = []
         until client.last_response.rels[:next].nil?
           begin
-            base_time = client.last_response.data.last.received_at.strftime("%Y-%m-%dT%H:%M:%SZ")
+            base_time = client.last_response.data.last.received_at
             error_events = fetch(base_time: base_time)
-            events.concat(error_events)
+            error_events.each do |error_event|
+              return events if error_event.received_at < start_date
+
+              events << error_event
+            end
             events.uniq!(&:id)
             puts "Currently #{events.size} events downloaded, in progress..."
           rescue Bugsnag::Api::RateLimitExceeded => e

--- a/lib/bugsnag_error_event_downloader/cli.rb
+++ b/lib/bugsnag_error_event_downloader/cli.rb
@@ -92,11 +92,22 @@ module BugsnagErrorEventDownloader
       required: true,
       type: :string,
       desc: "Path to the csv_map_path"
+    option :start_date,
+      required: false,
+      type: :numeric,
+      desc: "Path to the start_date in unix-time(default: current time)"
+    option :end_date,
+      required: false,
+      type: :numeric,
+      default: Time.now.to_i,
+      desc: "Path to the end_date in unix-time(default: 1 day ago)"
     def error_events
       Output.puts Commands::ErrorEvents.new(
         project_id: options[:project_id],
         error_id: options[:error_id],
-        csv_map_path: options[:csv_map_path]
+        csv_map_path: options[:csv_map_path],
+        start_date: options[:start_date] || options[:end_date] - (60 * 60 * 24 * 1),
+        end_date: options[:end_date]
       ).get
     rescue BugsnagErrorEventDownloader::NoAuthTokenError
       puts_error_no_auth_token_error

--- a/lib/bugsnag_error_event_downloader/commands/error_events.rb
+++ b/lib/bugsnag_error_event_downloader/commands/error_events.rb
@@ -3,10 +3,15 @@
 module BugsnagErrorEventDownloader
   module Commands
     class ErrorEvents
-      def initialize(project_id:, error_id:, csv_map_path:)
+      def initialize(project_id:, error_id:, csv_map_path:, start_date:, end_date:)
         errors = []
         begin
-          @client = BugsnagApiClient::ErrorEventClient.new(project_id: project_id, error_id: error_id)
+          @client = BugsnagApiClient::ErrorEventClient.new(
+            project_id: project_id,
+            error_id: error_id,
+            start_date: start_date,
+            end_date: end_date
+          )
         rescue ValidationError => e
           errors << e.attributes
         end

--- a/spec/lib/bugsnag_error_event_downloader/bugsnag_api_client/error_event_client_spec.rb
+++ b/spec/lib/bugsnag_error_event_downloader/bugsnag_api_client/error_event_client_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe(BugsnagErrorEventDownloader::BugsnagApiClient::ErrorEventClient) 
         project_url: "https://api.bugsnag.com/projects/11111",
         is_full_report: true,
         error_id: "22222",
-        received_at: "2022-01-01 00:00:00.000 UTC",
+        received_at: Time.now.utc - (60 * 60 * 1),
         exception: [
           {
             error_class: "NotFoundError",
@@ -98,7 +98,7 @@ RSpec.describe(BugsnagErrorEventDownloader::BugsnagApiClient::ErrorEventClient) 
         project_url: "https://api.bugsnag.com/projects/11111",
         is_full_report: true,
         error_id: "11111",
-        received_at: Time.parse("2022-01-01 00:00:00.000 UTC"),
+        received_at: Time.now.utc - (60 * 60 * 1),
         exception: [
           {
             error_class: "NotFoundError",
@@ -117,7 +117,7 @@ RSpec.describe(BugsnagErrorEventDownloader::BugsnagApiClient::ErrorEventClient) 
         project_url: "https://api.bugsnag.com/projects/11111",
         is_full_report: true,
         error_id: "11111",
-        received_at: Time.parse("2022-01-01 00:00:00.000 UTC"),
+        received_at: Time.now.utc - (60 * 60 * 2),
         exception: [
           {
             error_class: "NotFoundError",

--- a/spec/lib/bugsnag_error_event_downloader/commands/error_events_spec.rb
+++ b/spec/lib/bugsnag_error_event_downloader/commands/error_events_spec.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
 RSpec.describe(BugsnagErrorEventDownloader::Commands::ErrorEvents) do
-  let(:instance) { described_class.new(project_id: project_id, error_id: error_id, csv_map_path: csv_map_path) }
+  let(:instance) do
+    described_class.new(
+      project_id: project_id,
+      error_id: error_id,
+      csv_map_path: csv_map_path,
+      start_date: start_date,
+      end_date: end_date,
+    )
+  end
   let(:client) { instance_double(BugsnagErrorEventDownloader::BugsnagApiClient::ErrorEventClient) }
   let(:csv_converter) { instance_double(BugsnagErrorEventDownloader::Converter::CsvConverter) }
 
@@ -15,6 +23,8 @@ RSpec.describe(BugsnagErrorEventDownloader::Commands::ErrorEvents) do
       let(:project_id) { "project_id" }
       let(:error_id) { "error_id" }
       let(:csv_map_path) { "csv_map_path" }
+      let(:start_date) { Time.now.utc - (60 * 60 * 2) }
+      let(:end_date) { Time.now.utc - (60 * 60 * 1) }
 
       it { expect(instance).to(be_a(described_class)) }
     end
@@ -31,6 +41,8 @@ RSpec.describe(BugsnagErrorEventDownloader::Commands::ErrorEvents) do
       let(:project_id) { nil }
       let(:error_id) { "error_id" }
       let(:csv_map_path) { "csv_map_path" }
+      let(:start_date) { Time.now.utc - (60 * 60 * 2) }
+      let(:end_date) { Time.now.utc - (60 * 60 * 1) }
 
       it do
         expect { instance }.to(raise_error(BugsnagErrorEventDownloader::ValidationError) do |error|
@@ -51,6 +63,8 @@ RSpec.describe(BugsnagErrorEventDownloader::Commands::ErrorEvents) do
       let(:project_id) { "project_id" }
       let(:error_id) { "error_id" }
       let(:csv_map_path) { nil }
+      let(:start_date) { Time.now.utc - (60 * 60 * 2) }
+      let(:end_date) { Time.now.utc - (60 * 60 * 1) }
 
       it do
         expect { instance }.to(raise_error(BugsnagErrorEventDownloader::ValidationError) do |error|
@@ -76,6 +90,8 @@ RSpec.describe(BugsnagErrorEventDownloader::Commands::ErrorEvents) do
       let(:project_id) { nil }
       let(:error_id) { nil }
       let(:csv_map_path) { nil }
+      let(:start_date) { Time.now.utc - (60 * 60 * 2) }
+      let(:end_date) { Time.now.utc - (60 * 60 * 1) }
 
       it do
         expect { instance }.to(raise_error(BugsnagErrorEventDownloader::ValidationError) do |error|
@@ -91,6 +107,8 @@ RSpec.describe(BugsnagErrorEventDownloader::Commands::ErrorEvents) do
     let(:project_id) { "project_id" }
     let(:error_id) { "error_id" }
     let(:csv_map_path) { "csv_map_path" }
+    let(:start_date) { Time.now.utc - (60 * 60 * 2) }
+    let(:end_date) { Time.now.utc - (60 * 60 * 1) }
 
     let(:error_event) do
       agent = Sawyer::Agent.new("https://api.bugsnag.com")
@@ -100,7 +118,7 @@ RSpec.describe(BugsnagErrorEventDownloader::Commands::ErrorEvents) do
         project_url: "https://api.bugsnag.com/projects/11111",
         is_full_report: true,
         error_id: "22222",
-        received_at: "2022-01-01 00:00:00.000 UTC",
+        received_at: Time.now.utc - (60 * 60 * 1),
         exception: [
           {
             error_class: "NotFoundError",


### PR DESCRIPTION
The Bugsnag API client now accepts start and end date parameters. These parameters are used to fetch error events within a specific time range. The CLI has also been updated to accept these parameters.

example

```sh
bugsnag_error_event_downloader error_events -p $project_id -e $error_id -c csv_map.json --start_date=1695393860 --end_date=1695393960
```