### PR TITLE
Update BugsnagApiClient initialization in generate_csv_map.rb

### DIFF
--- a/lib/bugsnag_error_event_downloader/commands/generate_csv_map.rb
+++ b/lib/bugsnag_error_event_downloader/commands/generate_csv_map.rb
@@ -6,7 +6,11 @@ module BugsnagErrorEventDownloader
       include Thor::Base
 
       def initialize(project_id:, error_id:, include_stacktrace:, include_breadcrumbs:)
-        @client = BugsnagApiClient::ErrorEventClient.new(project_id: project_id, error_id: error_id)
+        @client = BugsnagApiClient::ErrorEventClient.new(
+          project_id: project_id,
+          error_id: error_id,
+          start_date: Time.now.to_i - 60 * 60 * 24 * 30,
+        )
         @include_stacktrace = include_stacktrace
         @include_breadcrumbs = include_breadcrumbs
       end


### PR DESCRIPTION
The BugsnagApiClient::ErrorEventClient initialization now includes a start_date parameter.

modified:   lib/bugsnag_error_event_downloader/commands/generate_csv_map.rb